### PR TITLE
Don't redefine _GNU_SOURCE if it's already set.

### DIFF
--- a/src/colors.c
+++ b/src/colors.c
@@ -2,7 +2,9 @@
  * Colours definition and setup function
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <ncurses.h>
 

--- a/src/data.c
+++ b/src/data.c
@@ -7,7 +7,9 @@
  * Also implements means of returning error information.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stdarg.h>
 #include <stdbool.h>

--- a/src/snb.c
+++ b/src/snb.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _XOPEN_SOURCE_EXTENDED 1
 
 #include <stdbool.h>

--- a/src/ui.c
+++ b/src/ui.c
@@ -2,7 +2,9 @@
  * Whole UI code in one place
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stdio.h>
 #include <stdbool.h>


### PR DESCRIPTION
Fixes #7.

@Celti, I'd be glad if you updated the `PKGBUILD` to include the `ncursesw6-config` patch after this is merged - seems to work fine for me with those two fixes!

(Also - yay, *finally* a sane `hnb` alternative! I had to stop using `hnb` because it only segfaulted, and never found a good replacement - `vimwiki` was good, but didn't quite cut it...)