### PR TITLE
Fix check_data.c to compile under musl-libc

### DIFF
--- a/tests/check_data.c
+++ b/tests/check_data.c
@@ -3,9 +3,6 @@
 #include <stdlib.h>
 
 #include <check.h>
-#ifdef _GNU_SOURCE
-#include <error.h>
-#endif
 #include <locale.h>
 #include <string.h>
 #include <wchar.h>

--- a/tests/check_data.c
+++ b/tests/check_data.c
@@ -3,7 +3,9 @@
 #include <stdlib.h>
 
 #include <check.h>
+#ifdef _GNU_SOURCE
 #include <error.h>
+#endif
 #include <locale.h>
 #include <string.h>
 #include <wchar.h>


### PR DESCRIPTION
Running `make full-check` on musl systems fails because:
```
tests/check_data.c:6:10: fatal error: error.h: No such file or directory
 #include <error.h>
          ^~~~~~~~~
compilation terminated.
```
as `check_data.c` does not use any of the functions defined in the library, it's safe to make this change.